### PR TITLE
This PR refactors the meal planner to focus on daily shuffle functionality instead of shuffling the whole week at once.

### DIFF
--- a/main/__init__.py
+++ b/main/__init__.py
@@ -2,7 +2,7 @@ from flask import Flask
 from flask import Config
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy 
-
+from flask_wtf.csrf import CSRFProtect
 from main.config import Config
 
 app = Flask(__name__)
@@ -10,6 +10,7 @@ app.config.from_object(Config)
 
 db = SQLAlchemy(app)
 migration = Migrate(app, db)
+csrf = CSRFProtect(app)
 
 from main import routes
 from main import models

--- a/main/mealplanner.py
+++ b/main/mealplanner.py
@@ -136,6 +136,21 @@ def get_plan_stats(week_plan, saved_recipes):
     }
 
 
+def get_shuffled_recipes(current_plan):
+    shuffled_recipes = []
+    used_recipe_ids = []
+
+    for day in current_plan:
+        for meal_type in current_plan[day]:
+            recipe = current_plan[day][meal_type]
+
+            if recipe is not None and recipe["id"] not in used_recipe_ids:
+                shuffled_recipes.append(recipe)
+                used_recipe_ids.append(recipe["id"])
+
+    return shuffled_recipes
+
+
 def get_meal_planner_context(days, meal_types, saved_recipes, user):
     action = request.args.get("action")
     day_to_delete = request.args.get("day")
@@ -160,6 +175,8 @@ def get_meal_planner_context(days, meal_types, saved_recipes, user):
 
     stats = get_plan_stats(current_plan, saved_recipes)
 
+    shuffled_recipes = get_shuffled_recipes(current_plan)
+
     generated_days = list(current_plan.keys())
 
     if len(generated_days) == 0:
@@ -180,5 +197,6 @@ def get_meal_planner_context(days, meal_types, saved_recipes, user):
         "meal_types": meal_types,
         "week_plan": current_plan,
         "saved_recipes": saved_recipes,
+        "shuffled_recipes": shuffled_recipes,
         "stats": stats
     }

--- a/main/mealplanner.py
+++ b/main/mealplanner.py
@@ -112,6 +112,10 @@ def get_meal_planner_context(days, meal_types, saved_recipes, user):
         session["meal_plan"] = delete_day_and_reorder(current_plan, day_to_delete)
         session.modified = True
 
+    elif action == "clear_all":
+        session["meal_plan"] = {}
+        session.modified = True
+
     stats = get_plan_stats(session["meal_plan"], saved_recipes)
 
     generated_days = list(session["meal_plan"].keys())

--- a/main/mealplanner.py
+++ b/main/mealplanner.py
@@ -90,9 +90,6 @@ def get_plan_stats(week_plan, saved_recipes):
 
 
 def get_meal_planner_context(days, meal_types, saved_recipes, user):
-    shuffle_type = request.args.get("shuffle")
-    shuffle_day = request.args.get("day")
-
     action = request.args.get("action")
     day_to_delete = request.args.get("day")
 

--- a/main/mealplanner.py
+++ b/main/mealplanner.py
@@ -101,14 +101,16 @@ def get_meal_planner_context(days, meal_types, saved_recipes, user):
 
     current_plan = session["meal_plan"]
 
-    if shuffle_type == "day":
+    if action == "shuffle_day":
         if len(current_plan) < 7:
             next_day = f"Day {len(current_plan) + 1}"
             current_plan[next_day] = make_one_day_plan(current_plan, meal_types, saved_recipes)
             session["meal_plan"] = current_plan
+            session.modified = True
 
     elif action == "delete_day":
         session["meal_plan"] = delete_day_and_reorder(current_plan, day_to_delete)
+        session.modified = True
 
     stats = get_plan_stats(session["meal_plan"], saved_recipes)
 

--- a/main/mealplanner.py
+++ b/main/mealplanner.py
@@ -34,37 +34,34 @@ def choose_recipe(meal_type, used_recipe_ids, saved_recipes):
     return selected_recipe
 
 
-def make_week_plan(days, meal_types, saved_recipes):
-    week_plan = {}
-    used_recipe_ids = []
-
-    for day in days:
-        week_plan[day] = {}
-
-        for meal_type in meal_types:
-            week_plan[day][meal_type] = choose_recipe(meal_type, used_recipe_ids, saved_recipes)
-
-    return week_plan
-
-
-def shuffle_single_day(current_plan, day, meal_types, saved_recipes):
+def make_one_day_plan(current_plan, meal_types, saved_recipes):
     used_recipe_ids = []
 
     for plan_day in current_plan:
-        if plan_day != day:
-            for meal_type in current_plan[plan_day]:
-                recipe = current_plan[plan_day][meal_type]
+        for meal_type in current_plan[plan_day]:
+            recipe = current_plan[plan_day][meal_type]
 
-                if recipe is not None:
-                    used_recipe_ids.append(recipe["id"])
+            if recipe is not None:
+                used_recipe_ids.append(recipe["id"])
 
-    current_plan[day] = {}
+    one_day_plan = {}
 
     for meal_type in meal_types:
-        current_plan[day][meal_type] = choose_recipe(meal_type, used_recipe_ids, saved_recipes)
+        one_day_plan[meal_type] = choose_recipe(meal_type, used_recipe_ids, saved_recipes)
 
-    return current_plan
+    return one_day_plan
 
+def delete_day_and_reorder(current_plan, day_to_delete):
+    if day_to_delete in current_plan:
+        current_plan.pop(day_to_delete)
+
+    old_day_plans = list(current_plan.values())
+    new_plan = {}
+
+    for index, day_plan in enumerate(old_day_plans, start=1):
+        new_plan[f"Day {index}"] = day_plan
+
+    return new_plan
 
 def get_plan_stats(week_plan, saved_recipes):
     meals_filled = 0
@@ -89,7 +86,6 @@ def get_plan_stats(week_plan, saved_recipes):
         "saved_count": len(saved_recipes),
         "meals_filled": meals_filled,
         "quickest_meal": quickest_meal,
-        "planner_mode": "Weekly"
     }
 
 
@@ -97,17 +93,31 @@ def get_meal_planner_context(days, meal_types, saved_recipes, user):
     shuffle_type = request.args.get("shuffle")
     shuffle_day = request.args.get("day")
 
+    action = request.args.get("action")
+    day_to_delete = request.args.get("day")
+
     if "meal_plan" not in session:
-        session["meal_plan"] = make_week_plan(days, meal_types, saved_recipes)
+        session["meal_plan"] = {}
 
-    if shuffle_type == "week":
-        session["meal_plan"] = make_week_plan(days, meal_types, saved_recipes)
+    current_plan = session["meal_plan"]
 
-    elif shuffle_type == "day" and shuffle_day in days:
-        current_plan = session["meal_plan"]
-        session["meal_plan"] = shuffle_single_day(current_plan, shuffle_day, meal_types, saved_recipes)
+    if shuffle_type == "day":
+        if len(current_plan) < 7:
+            next_day = f"Day {len(current_plan) + 1}"
+            current_plan[next_day] = make_one_day_plan(current_plan, meal_types, saved_recipes)
+            session["meal_plan"] = current_plan
+
+    elif action == "delete_day":
+        session["meal_plan"] = delete_day_and_reorder(current_plan, day_to_delete)
 
     stats = get_plan_stats(session["meal_plan"], saved_recipes)
+
+    generated_days = list(session["meal_plan"].keys())
+
+    if len(generated_days) == 0:
+        display_days = ["Day 1"]
+    else:
+        display_days = generated_days
 
     return {
         "page_title": "Plateful Meal Planner",
@@ -117,6 +127,8 @@ def get_meal_planner_context(days, meal_types, saved_recipes, user):
         "display_name": user["display_name"],
         "username": user["username"],
         "days": days,
+        "display_days": display_days,
+        "generated_days": generated_days,
         "meal_types": meal_types,
         "week_plan": session["meal_plan"],
         "saved_recipes": saved_recipes,

--- a/main/mealplanner.py
+++ b/main/mealplanner.py
@@ -90,7 +90,8 @@ def load_user_meal_plan(user):
 
 
 def save_user_meal_plan(user, meal_plan):
-    MealPlanEntry.query.filter_by(user_id=user["id"]).delete()
+    MealPlanEntry.query.filter_by(user_id=user["id"]).delete(synchronize_session=False)
+    db.session.flush()
 
     for day in meal_plan:
         for meal_type in meal_plan[day]:
@@ -154,6 +155,8 @@ def get_meal_planner_context(days, meal_types, saved_recipes, user):
     elif action == "clear_all":
         current_plan = {}
         save_user_meal_plan(user, current_plan)
+
+    current_plan = load_user_meal_plan(user)
 
     stats = get_plan_stats(current_plan, saved_recipes)
 

--- a/main/mealplanner.py
+++ b/main/mealplanner.py
@@ -1,6 +1,8 @@
 import random
 from datetime import datetime
-from flask import request, session
+from flask import request
+from main import db
+from main.models import MealPlanEntry
 
 
 def get_recipes_for_meal(meal_type, saved_recipes):
@@ -63,6 +65,50 @@ def delete_day_and_reorder(current_plan, day_to_delete):
 
     return new_plan
 
+
+def load_user_meal_plan(user):
+    entries = MealPlanEntry.query.filter_by(user_id=user["id"]).order_by(MealPlanEntry.day).all()
+
+    meal_plan = {}
+
+    for entry in entries:
+        if entry.day not in meal_plan:
+            meal_plan[entry.day] = {}
+
+        if entry.recipe is None:
+            meal_plan[entry.day][entry.meal_type] = None
+        else:
+            meal_plan[entry.day][entry.meal_type] = {
+                "id": entry.recipe.id,
+                "name": entry.recipe.title,
+                "time": entry.recipe.prep_time,
+                "meal_type": entry.recipe.meal_type,
+                "tag": entry.recipe.cuisine
+            }
+
+    return meal_plan
+
+
+def save_user_meal_plan(user, meal_plan):
+    MealPlanEntry.query.filter_by(user_id=user["id"]).delete()
+
+    for day in meal_plan:
+        for meal_type in meal_plan[day]:
+            recipe = meal_plan[day][meal_type]
+
+            entry = MealPlanEntry(
+                user_id=user["id"],
+                recipe_id=recipe["id"] if recipe else None,
+                day=day,
+                meal_type=meal_type,
+                week_start_date=datetime.now().date()
+            )
+
+            db.session.add(entry)
+
+    db.session.commit()
+
+
 def get_plan_stats(week_plan, saved_recipes):
     meals_filled = 0
     quickest_recipe = None
@@ -93,29 +139,25 @@ def get_meal_planner_context(days, meal_types, saved_recipes, user):
     action = request.args.get("action")
     day_to_delete = request.args.get("day")
 
-    if "meal_plan" not in session:
-        session["meal_plan"] = {}
-
-    current_plan = session["meal_plan"]
+    current_plan = load_user_meal_plan(user)
 
     if action == "shuffle_day":
         if len(current_plan) < 7:
             next_day = f"Day {len(current_plan) + 1}"
             current_plan[next_day] = make_one_day_plan(current_plan, meal_types, saved_recipes)
-            session["meal_plan"] = current_plan
-            session.modified = True
+            save_user_meal_plan(user, current_plan)
 
     elif action == "delete_day":
-        session["meal_plan"] = delete_day_and_reorder(current_plan, day_to_delete)
-        session.modified = True
+        current_plan = delete_day_and_reorder(current_plan, day_to_delete)
+        save_user_meal_plan(user, current_plan)
 
     elif action == "clear_all":
-        session["meal_plan"] = {}
-        session.modified = True
+        current_plan = {}
+        save_user_meal_plan(user, current_plan)
 
-    stats = get_plan_stats(session["meal_plan"], saved_recipes)
+    stats = get_plan_stats(current_plan, saved_recipes)
 
-    generated_days = list(session["meal_plan"].keys())
+    generated_days = list(current_plan.keys())
 
     if len(generated_days) == 0:
         display_days = ["Day 1"]
@@ -133,7 +175,7 @@ def get_meal_planner_context(days, meal_types, saved_recipes, user):
         "display_days": display_days,
         "generated_days": generated_days,
         "meal_types": meal_types,
-        "week_plan": session["meal_plan"],
+        "week_plan": current_plan,
         "saved_recipes": saved_recipes,
         "stats": stats
     }

--- a/main/models.py
+++ b/main/models.py
@@ -48,7 +48,7 @@ class Recipe(db.Model):
     ingredients = db.relationship("Ingredient", backref="recipe", lazy=True)
     steps = db.relationship("RecipeStep", backref="recipe", lazy=True)
     saved_by = db.relationship("SavedRecipe", backref="recipe", lazy=True)
-    meal_plan_entries = db.relationship("MealPlanEntry", backref="recipe", lazy=True)
+    meal_plan_entries = db.relationship("MealPlanEntry", backref="recipe", lazy=True, cascade="all, delete-orphan")
 
 class Ingredient(db.Model):
     __tablename__ = "ingredient"

--- a/main/routes.py
+++ b/main/routes.py
@@ -557,4 +557,3 @@ def privacy():
 @app.errorhandler(404)
 def page_not_found(error):
     return render_template('404.html'), 404
-

--- a/main/routes.py
+++ b/main/routes.py
@@ -172,6 +172,16 @@ def dashboard():
     )
     top_recipes = [{"recipe": r, "save_count": count} for r, count in top_recipes_raw]
 
+    followed_users = [
+        f.following for f in (
+            Follow.query
+            .filter_by(follower_id=user.id)
+            .order_by(Follow.followed_at.desc())
+            .limit(5)
+            .all()
+        )
+    ]
+
     raw_activity = (
         Activity.query
         .filter_by(user_id=user.id)
@@ -201,6 +211,8 @@ def dashboard():
         top_recipes=top_recipes,
         activity_feed=activity_feed,
         tip=_daily_tip(),
+        followed_users=followed_users,
+        page_date=date.today().strftime("%A, %d %B %Y"),
     )
 
 ## -------- Explore Page ---------------------------------------------

--- a/main/routes.py
+++ b/main/routes.py
@@ -1,16 +1,17 @@
 from flask import render_template, request, redirect, url_for, session
+from sqlalchemy import func
 
 from main.forms import LoginForm, RegisterForm
 from main import app, db
 from main.mealplanner import get_meal_planner_context
 from main.models import (
-    User, 
-    Recipe, 
-    Ingredient, 
-    RecipeStep, 
-    SavedRecipe, 
+    User,
+    Recipe,
+    Ingredient,
+    RecipeStep,
+    SavedRecipe,
     Follow,
-    Activity,   
+    Activity,
 )
 
 def get_current_user():
@@ -129,6 +130,44 @@ def dashboard():
         .count()
     )
 
+    recent_saved = [
+        item.recipe for item in (
+            SavedRecipe.query
+            .filter_by(user_id=user.id)
+            .order_by(SavedRecipe.saved_at.desc())
+            .limit(3)
+            .all()
+        )
+    ]
+
+    top_recipes_raw = (
+        db.session.query(Recipe, func.count(SavedRecipe.id).label("save_count"))
+        .outerjoin(SavedRecipe, SavedRecipe.recipe_id == Recipe.id)
+        .filter(Recipe.author_id == user.id)
+        .group_by(Recipe.id)
+        .order_by(func.count(SavedRecipe.id).desc())
+        .limit(5)
+        .all()
+    )
+    top_recipes = [{"recipe": r, "save_count": count} for r, count in top_recipes_raw]
+
+    raw_activity = (
+        Activity.query
+        .filter_by(user_id=user.id)
+        .order_by(Activity.created_at.desc())
+        .limit(5)
+        .all()
+    )
+    activity_feed = []
+    for item in raw_activity:
+        if item.activity_type == "uploaded_recipe" and item.related_recipe:
+            text = f"Uploaded recipe: {item.related_recipe.title}"
+        elif item.activity_type == "saved_recipe" and item.related_recipe:
+            text = f"Saved recipe: {item.related_recipe.title}"
+        else:
+            text = item.activity_type
+        activity_feed.append({"text": text, "time": item.created_at.strftime("%d %b %Y")})
+
     return render_template(
         "dashboard.html",
         **user_context(user),
@@ -137,6 +176,9 @@ def dashboard():
         saved_count=saved_count,
         following_count=following_count,
         total_saves=total_saves,
+        recent_saved=recent_saved,
+        top_recipes=top_recipes,
+        activity_feed=activity_feed,
     )
 
 ## -------- Explore Page ---------------------------------------------

--- a/main/routes.py
+++ b/main/routes.py
@@ -38,6 +38,7 @@ def user_context(user=None):
         }
 
     return {
+        "id": user.id,
         "initials": user.display_name[:2].upper(),
         "display_name": user.display_name,
         "username": f"@{user.username}",
@@ -228,12 +229,9 @@ def meal_planner():
 
     user = get_current_user()
 
-    days = [
-        "Monday", "Tuesday", "Wednesday", "Thursday",
-        "Friday", "Saturday", "Sunday"
-    ]
-
     meal_types = ["Breakfast", "Lunch", "Dinner"]
+
+    days = ["Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6", "Day 7"]
 
     saved_items = SavedRecipe.query.filter_by(user_id=user.id).all()
 

--- a/main/routes.py
+++ b/main/routes.py
@@ -237,6 +237,7 @@ def meal_planner():
 
     saved_recipes = [
         {
+            "id": saved.recipe.id,
             "name": saved.recipe.title,
             "meal_type": saved.recipe.meal_type or "Meal",
             "tag": saved.recipe.cuisine or "Recipe",
@@ -556,3 +557,4 @@ def privacy():
 @app.errorhandler(404)
 def page_not_found(error):
     return render_template('404.html'), 404
+

--- a/main/routes.py
+++ b/main/routes.py
@@ -353,6 +353,22 @@ def profile():
         .count()
     )
 
+    recipes = (
+        Recipe.query
+        .filter_by(author_id=user.id)
+        .order_by(Recipe.created_at.desc())
+        .all()
+    )
+
+    saved_recipes = [
+        item.recipe for item in (
+            SavedRecipe.query
+            .filter_by(user_id=user.id)
+            .order_by(SavedRecipe.saved_at.desc())
+            .all()
+        )
+    ]
+
     activities = (
         Activity.query
         .filter_by(user_id=user.id)
@@ -385,6 +401,8 @@ def profile():
         followers_count=followers_count,
         total_saves=total_saves,
         activity=activity_feed,
+        recipes=recipes,
+        saved_recipes=saved_recipes,
     )
 
 ## -------- Settings Page ---------------------------------------------

--- a/main/routes.py
+++ b/main/routes.py
@@ -1,3 +1,4 @@
+from datetime import date
 from flask import render_template, request, redirect, url_for, session
 from sqlalchemy import func
 
@@ -110,6 +111,26 @@ def signup():
 
     return redirect(url_for("dashboard"))
 
+_TIPS = [
+    "Salt your pasta water until it tastes like the sea — it's your only chance to season the pasta itself.",
+    "Pat meat dry before searing. Moisture is the enemy of a good crust.",
+    "Taste as you go. Seasoning at the end can't fix under-seasoned layers.",
+    "Rest your meat after cooking — 5 minutes makes a big difference in juiciness.",
+    "Cold butter whisked into a sauce at the end gives it a glossy, restaurant finish.",
+    "Toast your spices in a dry pan before grinding to unlock deeper flavour.",
+    "Acid (lemon, vinegar) added at the end brightens a dish that tastes flat.",
+    "Use the pasta cooking water to loosen and bind your sauce — the starch is key.",
+    "Room-temperature eggs and dairy incorporate more evenly into batters.",
+    "A pinch of sugar balances acidic tomato sauces without making them sweet.",
+    "Slice meat against the grain to shorten muscle fibres and make it more tender.",
+    "Fresh herbs go in at the end; dried herbs go in early so they have time to bloom.",
+]
+
+
+def _daily_tip():
+    return _TIPS[date.today().timetuple().tm_yday % len(_TIPS)]
+
+
 ## -------- Dashboard ---------------------------------------------
 @app.route("/dashboard", methods=["GET"])
 def dashboard():
@@ -179,6 +200,7 @@ def dashboard():
         recent_saved=recent_saved,
         top_recipes=top_recipes,
         activity_feed=activity_feed,
+        tip=_daily_tip(),
     )
 
 ## -------- Explore Page ---------------------------------------------

--- a/main/static/styles.css
+++ b/main/static/styles.css
@@ -286,9 +286,18 @@ body.page-meal-planner .page-intro h2 { font-size: 1.55rem; }
   font-size: 0.82rem;
   font-weight: 600;
   cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+  transition: 0.2s ease;
 }
 .btn-soft { background: #fff; color: var(--color-text); }
 .btn-solid { background: var(--color-surface); color: var(--color-text); }
+.btn-solid:hover {
+  background: #fff8da;
+  border-color: #b9ad86;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+}
 
 .summary-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-bottom: 26px; }
 .summary-card { background: var(--color-surface); border: 1px solid #d8d0b0; border-radius: 14px; padding: 16px 18px; }
@@ -353,6 +362,37 @@ thead th:first-child { width: 98px; background: #f6f3e5; }
   body.page-meal-planner .page-intro { flex-direction: column; }
 }
 
+
+.day-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+/* ─── Delete button in head row of table ─── */
+.delete-day-btn {
+    padding: 4px 10px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+
+    background-color: white;
+
+    font-size: 12px;
+    font-weight: 500;
+
+    text-decoration: none;
+    color: #374151;
+
+    transition: 0.2s ease;
+
+    display: inline-block;
+    cursor: pointer;
+}
+
+.delete-day-btn:hover {
+    background-color: #f3f4f6;
+    border-color: #9ca3af;
+}
 
 /* ════════════════════════════════════════════
    PAGE: EXPLORE
@@ -1451,3 +1491,11 @@ body.page-profile .columns { display: grid; grid-template-columns: 1fr 260px; ga
 .logout-form { margin-top: 10px; }
 .logout-btn { width: 100%; padding: 8px 12px; background: none; border: 1.5px solid #d8d0b0; border-radius: 8px; font-family: var(--font-body); font-size: 0.82rem; font-weight: 600; color: var(--color-muted); cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
 .logout-btn:hover { background: #fdf0f0; border-color: #e8b0b0; color: #c0392b; }
+
+
+
+/* ════════════════════════════════════════════
+   PAGE: MEALPLANNER
+════════════════════════════════════════════ */
+
+

--- a/main/static/styles.css
+++ b/main/static/styles.css
@@ -394,6 +394,71 @@ thead th:first-child { width: 98px; background: #f6f3e5; }
     border-color: #9ca3af;
 }
 
+
+/* ─── Clear all button at the botton of table ─── */
+.clear-planner-btn {
+  border: 1px solid #d8d0b0;
+  border-radius: 10px;
+  padding: 9px 14px;
+  background: #fff;
+  color: var(--color-text);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: 0.2s ease;
+}
+
+.clear-planner-btn:hover {
+  background: #fff8da;
+  border-color: #b9ad86;
+  transform: translateY(-1px);
+}
+
+.confirm-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  justify-content: center;
+  align-items: center;
+  z-index: 999;
+}
+
+.confirm-box {
+  background: #fff;
+  border-radius: 16px;
+  padding: 24px;
+  width: 360px;
+  max-width: 90%;
+  text-align: center;
+  border: 1px solid #ddd4b8;
+}
+
+.confirm-actions {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.confirm-yes,
+.confirm-no {
+  border: 1px solid #d8d0b0;
+  border-radius: 10px;
+  padding: 8px 18px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.confirm-yes:hover,
+.confirm-no:hover {
+  background: #fff8da;
+}
+
 /* ════════════════════════════════════════════
    PAGE: EXPLORE
 ════════════════════════════════════════════ */

--- a/main/static/styles.css
+++ b/main/static/styles.css
@@ -395,6 +395,17 @@ thead th:first-child { width: 98px; background: #f6f3e5; }
 }
 
 
+/* ─── link to each recipe details ─── */
+.meal-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.meal-link:hover {
+  text-decoration: underline;
+}
+
+
 /* ─── Clear all button at the botton of table ─── */
 .clear-planner-btn {
   border: 1px solid #d8d0b0;

--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -42,6 +42,7 @@
           </div>
         </div>
           <form action="{{ url_for('logout') }}" method="post" class="logout-form">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="logout-btn">Log out</button>
           </form>
         {% endblock %}

--- a/main/templates/dashboard.html
+++ b/main/templates/dashboard.html
@@ -122,8 +122,8 @@
     </section>
 
     <div class="weather-card">
-      <p class="w-top">Local update</p>
-      <p class="w-msg">{{ weather_msg|default('') }}</p>
+      <p class="w-top">Tip of the day</p>
+      <p class="w-msg">{{ tip }}</p>
       <a href="{{ url_for('explore') }}">Browse recipes →</a>
     </div>
   </div>

--- a/main/templates/dashboard.html
+++ b/main/templates/dashboard.html
@@ -117,7 +117,14 @@
         <a href="{{ url_for('following') }}">See all</a>
       </div>
       <ul class="follow-list">
-        <p class="empty-state">No suggested accounts yet.</p>
+        {% for u in followed_users %}
+        <li class="follow-item">
+          <span class="follow-name">{{ u.display_name }}</span>
+          <span class="follow-handle">@{{ u.username }}</span>
+        </li>
+        {% else %}
+        <p class="empty-state">You're not following anyone yet.</p>
+        {% endfor %}
       </ul>
     </section>
 

--- a/main/templates/dashboard.html
+++ b/main/templates/dashboard.html
@@ -57,7 +57,22 @@
         <a href="{{ url_for('saved_recipes') }}">See all</a>
       </div>
       <div class="recipe-grid">
-        <p class="empty-state">No recipes added yet.</p>
+        {% for recipe in recent_saved %}
+        <div class="recipe-card">
+          <div class="recipe-thumb"></div>
+          <div class="recipe-body">
+            <p class="recipe-name">{{ recipe.title }}</p>
+            <p class="recipe-by">by {{ recipe.author.display_name }}</p>
+            <div class="recipe-meta">
+              <span class="tag">{{ recipe.cuisine }}</span>
+              <span>{{ recipe.prep_time }} min</span>
+            </div>
+            <a href="{{ url_for('recipe_details', recipe_id=recipe.id) }}" class="btn">View</a>
+          </div>
+        </div>
+        {% else %}
+        <p class="empty-state">No recipes saved yet.</p>
+        {% endfor %}
       </div>
     </section>
 
@@ -67,7 +82,14 @@
         <a href="{{ url_for('my_recipes') }}">Manage</a>
       </div>
       <ul class="pop-list">
+        {% for item in top_recipes %}
+        <li class="pop-item">
+          <a href="{{ url_for('recipe_details', recipe_id=item.recipe.id) }}" class="pop-title">{{ item.recipe.title }}</a>
+          <span class="pop-saves">{{ item.save_count }} save{{ 's' if item.save_count != 1 else '' }}</span>
+        </li>
+        {% else %}
         <p class="empty-state">No top recipes to show yet.</p>
+        {% endfor %}
       </ul>
     </section>
   </div>
@@ -78,7 +100,14 @@
         <h3>Activity</h3>
       </div>
       <div class="feed">
+        {% for item in activity_feed %}
+        <div class="feed-item">
+          <span class="feed-text">{{ item.text }}</span>
+          <span class="feed-time">{{ item.time }}</span>
+        </div>
+        {% else %}
         <p class="empty-state">No recent activity yet.</p>
+        {% endfor %}
       </div>
     </section>
 

--- a/main/templates/edit_recipe.html
+++ b/main/templates/edit_recipe.html
@@ -13,6 +13,7 @@
 {% block content %}
 <div class="form-card">
   <form action="{{ url_for('edit_recipe', recipe_id=recipe_id|default(0)) }}" method="post" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <h1>Edit recipe</h1>
     <p class="sub">Update your recipe details here.</p>
 

--- a/main/templates/forgot_password.html
+++ b/main/templates/forgot_password.html
@@ -22,6 +22,7 @@
   </div>
 
   <form method="post" action="{{ url_for('forgot_password') }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="field">
       <label for="reset-email">Email</label>
       <input type="email" id="reset-email" name="email" placeholder="" />

--- a/main/templates/login.html
+++ b/main/templates/login.html
@@ -32,6 +32,7 @@
 
   <!-- LOGIN -->
   <form action="{{ url_for('login') }}" method="post" id="panel-login" class="form-panel active">
+    {{ login_form.hidden_tag() }}
     <div class="form-heading">
       <h2>{{ greeting|default('Welcome') }} back</h2>
       <p>Sign in to your account</p>
@@ -66,6 +67,7 @@
 
   <!-- SIGN UP -->
   <form action="{{ url_for('signup') }}" method="post" id="panel-signup" class="form-panel">
+    {{ signup_form.hidden_tag() }}
     <div class="form-heading">
       <h2>Join Plateful</h2>
       <p>Create a new account</p>

--- a/main/templates/mealplanner.html
+++ b/main/templates/mealplanner.html
@@ -85,7 +85,9 @@
 
                 {% if recipe %}
                   <div class="meal-card {{ meal_type|lower }}">
-                    <div class="meal-name">{{ recipe.name }}</div>
+                    <a href="{{ url_for('recipe_details', recipe_id=recipe.id) }}" class="meal-name meal-link">
+                      {{ recipe.name }}
+                    </a>
                     <div class="meal-meta">
                       <span>{{ recipe.time }} mins</span>
                       <span>{{ recipe.meal_type }}</span>
@@ -125,7 +127,9 @@
             <div class="mini-left">
               <div class="mini-icon">🍽️</div>
               <div>
-                <div class="mini-name">{{ recipe.name }}</div>
+                <a href="{{ url_for('recipe_details', recipe_id=recipe.id) }}" class="mini-name meal-link">
+                  {{ recipe.name }}
+                </a>
                 <div class="mini-sub">{{ recipe.meal_type }} · {{ recipe.tag }}</div>
               </div>
             </div>

--- a/main/templates/mealplanner.html
+++ b/main/templates/mealplanner.html
@@ -116,13 +116,13 @@
     <section class="panel">
       <div class="panel-header">
         <div>
-          <h3>Shuffled recipes pool</h3>
-          <p>Examples of recipes the planner can draw from.</p>
+          <h3>Current shuffled recipes pool</h3>
+          <p>A list of recipes currently shuffled in the meal planner table.</p>
         </div>
       </div>
 
-      {% if saved_recipes %}
-        {% for recipe in saved_recipes %}
+      {% if shuffled_recipes %}
+        {% for recipe in shuffled_recipes %}
           <div class="mini-item">
             <div class="mini-left">
               <div class="mini-icon">🍽️</div>

--- a/main/templates/mealplanner.html
+++ b/main/templates/mealplanner.html
@@ -32,11 +32,6 @@
     <div class="value">{{ stats.meals_filled }}</div>
     <div class="hint"></div>
   </div>
-  <div class="summary-card">
-    <div class="label">Quickest meal</div>
-    <div class="value">{{ stats.quickest_meal }}</div>
-    <div class="hint"></div>
-  </div>
 </div>
 
 <div class="planner-layout">
@@ -108,11 +103,10 @@
         </tbody>
       </table>
     </div>
-
     <div class="legend">
-      {% for meal_type in meal_types %}
-        <span>{{ meal_type }}</span>
-      {% endfor %}
+      <button type="button" class="clear-planner-btn" onclick="openClearConfirm()">
+        Clear all to shuffle a new meal planner
+      </button>
     </div>
   </section>
 
@@ -144,4 +138,30 @@
     </section>
   </div>
 </div>
+
+<div id="clearConfirmModal" class="confirm-modal">
+  <div class="confirm-box">
+    <p>Do you really want to clear your current meal planner?</p>
+
+    <div class="confirm-actions">
+      <a href="{{ url_for('meal_planner', action='clear_all') }}" class="confirm-yes">
+        Yes
+      </a>
+
+      <button type="button" class="confirm-no" onclick="closeClearConfirm()">
+        No
+      </button>
+    </div>
+  </div>
+</div>
+
+<script>
+  function openClearConfirm() {
+    document.getElementById("clearConfirmModal").style.display = "flex";
+  }
+
+  function closeClearConfirm() {
+    document.getElementById("clearConfirmModal").style.display = "none";
+  }
+</script>
 {% endblock %}

--- a/main/templates/mealplanner.html
+++ b/main/templates/mealplanner.html
@@ -17,14 +17,7 @@
 <div class="page-intro">
   <div>
     <h2>Meal planner</h2>
-    <p>Build your weekly planner from your saved recipes.</p>
-  </div>
-
-  <div class="planner-actions">
-    <a href="{{ url_for('meal_planner', shuffle='week') }}" class="btn-solid">Shuffle week</a>
-    {% if days %}
-      <a href="{{ url_for('meal_planner', shuffle='day', day=days[0]) }}" class="btn-soft">Shuffle one day</a>
-    {% endif %}
+    <p>Build your own meal planner from your saved recipes.</p>
   </div>
 </div>
 
@@ -44,21 +37,25 @@
     <div class="value">{{ stats.quickest_meal }}</div>
     <div class="hint"></div>
   </div>
-  <div class="summary-card">
-    <div class="label">Planner mode</div>
-    <div class="value">{{ stats.planner_mode }}</div>
-    <div class="hint"></div>
-  </div>
 </div>
 
 <div class="planner-layout">
   <section class="panel">
     <div class="panel-header">
       <div>
-        <h3>Weekly planner table</h3>
-        <p>Each cell is a saved recipe suggestion for that meal slot.</p>
+        <h3>Your own meal planner table</h3>
+        <p>Click "shuffle one day" button to generate daily meal planner and delete what you do not like. Maxium 7 days to shuffle.</p>
       </div>
-      <div class="meal-tag">{{ stats.planner_mode }}</div>
+      
+      <div class="planner-actions">
+        {% if generated_days|length < 7 %}
+          <a href="{{ url_for('meal_planner', action='shuffle_day') }}" class="btn-solid">
+            Shuffle one day
+          </a>
+        {% else %}
+          <button class="btn-solid" disabled>Maximum 7 days reached</button>
+        {% endif %}
+      </div>
     </div>
 
     <div class="week-table-wrap">
@@ -66,18 +63,30 @@
         <thead>
           <tr>
             <th>Meal</th>
-            {% for day in days %}
-              <th>{{ day }}</th>
-            {% endfor %}
+              {% for day in display_days %}
+                <th>
+                  <div class="day-header">
+                    <span>Day {{ loop.index }}</span>
+
+                    {% if day in generated_days %}
+                      <a href="{{ url_for('meal_planner', action='delete_day', day=day) }}" class="delete-day-link">
+                        Delete
+                      </a>
+                    {% endif %}
+                  </div>
+                </th>
+              {% endfor %}
           </tr>
         </thead>
         <tbody>
           {% for meal_type in meal_types %}
           <tr>
             <td class="meal-label">{{ meal_type }}</td>
-            {% for day in days %}
+
+            {% for day in display_days %}
               <td class="meal-cell">
-                {% set recipe = week_plan[day][meal_type] %}
+                {% set recipe = week_plan.get(day, {}).get(meal_type) %}
+
                 {% if recipe %}
                   <div class="meal-card {{ meal_type|lower }}">
                     <div class="meal-name">{{ recipe.name }}</div>
@@ -88,7 +97,7 @@
                   </div>
                 {% else %}
                   <div class="meal-card {{ meal_type|lower }}">
-                    <p class="empty-table">No recipe available</p>
+                    <p class="empty-table">No meals yet</p>
                   </div>
                 {% endif %}
               </td>
@@ -110,7 +119,7 @@
     <section class="panel">
       <div class="panel-header">
         <div>
-          <h3>Saved recipes pool</h3>
+          <h3>Shuffled recipes pool</h3>
           <p>Examples of recipes the planner can draw from.</p>
         </div>
       </div>
@@ -129,7 +138,7 @@
           </div>
         {% endfor %}
       {% else %}
-        <div class="empty-note">No saved recipes yet.</div>
+        <div class="empty-note">No shuffled recipes yet.</div>
       {% endif %}
     </section>
   </div>

--- a/main/templates/mealplanner.html
+++ b/main/templates/mealplanner.html
@@ -35,7 +35,7 @@
 </div>
 
 <div class="planner-layout">
-  <section class="panel">
+  <section class="panel" id="meal-planner-table">
     <div class="panel-header">
       <div>
         <h3>Your own meal planner table</h3>
@@ -44,7 +44,7 @@
       
       <div class="planner-actions">
         {% if generated_days|length < 7 %}
-          <a href="{{ url_for('meal_planner', action='shuffle_day') }}" class="btn-solid">
+          <a href="{{ url_for('meal_planner', action='shuffle_day', count=generated_days|length, _anchor='meal-planner-table') }}" class="btn-solid">
             Shuffle one day
           </a>
         {% else %}
@@ -64,7 +64,7 @@
                     <span>Day {{ loop.index }}</span>
 
                     {% if day in generated_days %}
-                      <a href="{{ url_for('meal_planner', action='delete_day', day=day) }}"
+                      <a href="{{ url_for('meal_planner', action='delete_day', day=day, _anchor='meal-planner-table') }}"
                         class="delete-day-btn">
                         Delete
                       </a>
@@ -144,7 +144,7 @@
     <p>Do you really want to clear your current meal planner?</p>
 
     <div class="confirm-actions">
-      <a href="{{ url_for('meal_planner', action='clear_all') }}" class="confirm-yes">
+      <a href="{{ url_for('meal_planner', action='clear_all', _anchor='meal-planner-table') }}" class="confirm-yes">
         Yes
       </a>
 

--- a/main/templates/mealplanner.html
+++ b/main/templates/mealplanner.html
@@ -144,9 +144,9 @@
     <p>Do you really want to clear your current meal planner?</p>
 
     <div class="confirm-actions">
-      <a href="{{ url_for('meal_planner', action='clear_all', _anchor='meal-planner-table') }}" class="confirm-yes">
+      <button type="button" class="confirm-yes" onclick="confirmClearPlanner()">
         Yes
-      </a>
+      </button>
 
       <button type="button" class="confirm-no" onclick="closeClearConfirm()">
         No
@@ -162,6 +162,10 @@
 
   function closeClearConfirm() {
     document.getElementById("clearConfirmModal").style.display = "none";
+  }
+
+  function confirmClearPlanner() {
+    window.location.href = "{{ url_for('meal_planner', action='clear_all') }}" + "&t=" + Date.now() + "#meal-planner-table";
   }
 </script>
 {% endblock %}

--- a/main/templates/mealplanner.html
+++ b/main/templates/mealplanner.html
@@ -44,7 +44,7 @@
     <div class="panel-header">
       <div>
         <h3>Your own meal planner table</h3>
-        <p>Click "shuffle one day" button to generate daily meal planner and delete what you do not like. Maxium 7 days to shuffle.</p>
+        <p>Click "Shuffle one day" to add one day meal planner at a time. You can delete any day you do not want. Maximum 7 days.</p>
       </div>
       
       <div class="planner-actions">
@@ -69,7 +69,8 @@
                     <span>Day {{ loop.index }}</span>
 
                     {% if day in generated_days %}
-                      <a href="{{ url_for('meal_planner', action='delete_day', day=day) }}" class="delete-day-link">
+                      <a href="{{ url_for('meal_planner', action='delete_day', day=day) }}"
+                        class="delete-day-btn">
                         Delete
                       </a>
                     {% endif %}

--- a/main/templates/mealplanner.html
+++ b/main/templates/mealplanner.html
@@ -64,7 +64,7 @@
                     <span>Day {{ loop.index }}</span>
 
                     {% if day in generated_days %}
-                      <a href="{{ url_for('meal_planner', action='delete_day', day=day, _anchor='meal-planner-table') }}"
+                      <a href="{{ url_for('meal_planner', action='delete_day', day=day, t=range(1000000)|random, _anchor='meal-planner-table') }}"
                         class="delete-day-btn">
                         Delete
                       </a>

--- a/main/templates/mealplanner.html
+++ b/main/templates/mealplanner.html
@@ -17,7 +17,7 @@
 <div class="page-intro">
   <div>
     <h2>Meal planner</h2>
-    <p>Build your own meal planner from your saved recipes.</p>
+    <p>Build your own meal planner from your saved recipes. Your meal planner table will be saved automatically.</p>
   </div>
 </div>
 

--- a/main/templates/profile.html
+++ b/main/templates/profile.html
@@ -81,7 +81,21 @@
     <a href="{{ url_for('upload_recipe') }}">+ New Recipe</a>
   </div>
   <div class="recipe-grid">
+    {% for recipe in recipes %}
+    <div class="recipe-card">
+      <div class="recipe-thumb"></div>
+      <div class="recipe-body">
+        <p class="recipe-name">{{ recipe.title }}</p>
+        <div class="recipe-meta">
+          <span class="tag">{{ recipe.cuisine }}</span>
+          <span>{{ recipe.prep_time }} min</span>
+        </div>
+        <a href="{{ url_for('recipe_details', recipe_id=recipe.id) }}" class="btn">View</a>
+      </div>
+    </div>
+    {% else %}
     <p class="empty-state">No recipes posted yet.</p>
+    {% endfor %}
   </div>
 </div>
 
@@ -91,7 +105,24 @@
     <h3>Saved recipes</h3>
     <span style="font-size:0.78rem; color:var(--color-muted);">{{ saved_count|default(0) }} recipe{{ 's' if saved_count != 1 else '' }}</span>
   </div>
-  <p class="empty-state">No saved recipes yet.</p>
+  <div class="recipe-grid">
+    {% for recipe in saved_recipes %}
+    <div class="recipe-card">
+      <div class="recipe-thumb"></div>
+      <div class="recipe-body">
+        <p class="recipe-name">{{ recipe.title }}</p>
+        <p class="recipe-by">by {{ recipe.author.display_name }}</p>
+        <div class="recipe-meta">
+          <span class="tag">{{ recipe.cuisine }}</span>
+          <span>{{ recipe.prep_time }} min</span>
+        </div>
+        <a href="{{ url_for('recipe_details', recipe_id=recipe.id) }}" class="btn">View</a>
+      </div>
+    </div>
+    {% else %}
+    <p class="empty-state">No saved recipes yet.</p>
+    {% endfor %}
+  </div>
 </div>
 
 <!-- TAB: ACTIVITY -->

--- a/main/templates/recipe_details.html
+++ b/main/templates/recipe_details.html
@@ -22,6 +22,7 @@
 
     <div class="actions">
       <form action="{{ url_for('save_recipe', recipe_id=recipe_id|default(0)) }}" method="post" style="display:inline;">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <button type="submit" class="btn primary">Save</button>
       </form>
       <button type="button" class="btn">Share</button>

--- a/main/templates/recipe_details.html
+++ b/main/templates/recipe_details.html
@@ -16,7 +16,7 @@
     <div class="recipe-header">
       <h1>{{ recipe.title|default('Recipe title') }}</h1>
       <div class="recipe-meta">
-        {{ recipe.cuisine|default('Cuisine') }} · {{ recipe.prep_time|default('Time') }} · {{ recipe.difficulty|default('Difficulty') }} · by {{ recipe.author|default(username|default('@username')) }}
+        {{ recipe.cuisine|default('Cuisine') }} · {{ recipe.prep_time|default('Time') }} minutes · {{ recipe.difficulty|default('Difficulty') }} · by {{ recipe.author.display_name|default(username|default('@username')) }}
       </div>
     </div>
 

--- a/main/templates/saved_recipe.html
+++ b/main/templates/saved_recipe.html
@@ -50,6 +50,21 @@
 </div>
 
 <div class="recipe-grid">
+  {% for recipe in recipes %}
+  <div class="recipe-card">
+    <div class="recipe-thumb"></div>
+    <div class="recipe-body">
+      <p class="recipe-name">{{ recipe.title }}</p>
+      <p class="recipe-by">by {{ recipe.author.display_name }}</p>
+      <div class="recipe-meta">
+        <span class="tag">{{ recipe.cuisine }}</span>
+        <span>{{ recipe.prep_time }} min</span>
+      </div>
+      <a href="{{ url_for('recipe_details', recipe_id=recipe.id) }}" class="btn">View</a>
+    </div>
+  </div>
+  {% else %}
   <p class="empty-state">No saved recipes yet.</p>
+  {% endfor %}
 </div>
 {% endblock %}

--- a/main/templates/upload_recipe.html
+++ b/main/templates/upload_recipe.html
@@ -12,6 +12,7 @@
 {% block content %}
 <div class="form-card">
   <form action="{{ url_for('upload_recipe') }}" method="post" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <h1>Upload recipe</h1>
 
     <div class="form-group">


### PR DESCRIPTION
**Changes made:**

1. Removed the Shuffle week button from the meal planner page.
2. Updated the meal planner flow to use Shuffle one day only.
3. Updated the table headings from weekdays to Day 1–Day 7.
4. Added support for generating one day at a time, up to 7 days.
5. Added Delete buttons for generated days.
6. Added logic so that when a day is deleted, later days shift forward automatically.
7. Removed the Planner mode display.
8. Updated meal planner UI styling for buttons and delete actions.

**Related issue**
Closes #54

-----------------

**Additional Changes made:**

1. Added persistent meal planner saving using the database instead of temporary session storage.
2. Added Clear all button with confirmation popup.
3. Added clickable recipe links in the meal planner table and shuffled recipes pool.
4. Fixed delete button issues for meal planner days.
5. Updated shuffled recipes pool so it only shows recipes currently in the table.


**Related issue**
Closes #69
Closes #70 
Closes #71 
Closes #72 
Closes #73