### PR TITLE
Add social discovery features — public profiles, suggested accounts, follow from recipe

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -45,11 +45,11 @@ class Recipe(db.Model):
     updated_at = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
     ## relationships
-    ingredients = db.relationship("Ingredient", backref="recipe", lazy=True)
-    steps = db.relationship("RecipeStep", backref="recipe", lazy=True)
-    saved_by = db.relationship("SavedRecipe", backref="recipe", lazy=True)
+    ingredients = db.relationship("Ingredient", backref="recipe", lazy=True, cascade="all, delete-orphan")
+    steps = db.relationship("RecipeStep", backref="recipe", lazy=True, cascade="all, delete-orphan")
+    saved_by = db.relationship("SavedRecipe", backref="recipe", lazy=True, cascade="all, delete-orphan")
     meal_plan_entries = db.relationship("MealPlanEntry", backref="recipe", lazy=True, cascade="all, delete-orphan")
-
+    
 class Ingredient(db.Model):
     __tablename__ = "ingredient"
 

--- a/main/routes.py
+++ b/main/routes.py
@@ -708,13 +708,31 @@ def recipe_details(recipe_id):
     if redirect_response:
         return redirect_response
 
+    current_user = get_current_user()
     recipe = Recipe.query.get_or_404(recipe_id)
+
+    is_own_recipe = recipe.author_id == current_user.id
+
+    is_following_author = False
+    if not is_own_recipe:
+        is_following_author = Follow.query.filter_by(
+            follower_id=current_user.id,
+            following_id=recipe.author_id
+        ).first() is not None
+
+    is_saved = SavedRecipe.query.filter_by(
+        user_id=current_user.id,
+        recipe_id=recipe.id
+    ).first() is not None
 
     return render_template(
         "recipe_details.html",
-        **user_context(),
+        **user_context(current_user),
         recipe=recipe,
         recipe_id=recipe.id,
+        is_own_recipe=is_own_recipe,
+        is_following_author=is_following_author,
+        is_saved=is_saved,
     )
 
 ## -------- Edit Recipe Page ---------------------------------------------

--- a/main/routes.py
+++ b/main/routes.py
@@ -223,6 +223,8 @@ def dashboard():
             text = f"Uploaded recipe: {item.related_recipe.title}"
         elif item.activity_type == "saved_recipe" and item.related_recipe:
             text = f"Saved recipe: {item.related_recipe.title}"
+        elif item.activity_type == "followed_user" and item.related_user:
+            text = f"Followed {item.related_user.display_name}"
         else:
             text = item.activity_type
         activity_feed.append({"text": text, "time": item.created_at.strftime("%d %b %Y")})
@@ -577,6 +579,8 @@ def profile():
             text = f"Uploaded recipe: {item.related_recipe.title}"
         elif item.activity_type == "saved_recipe" and item.related_recipe:
             text = f"Saved recipe: {item.related_recipe.title}"
+        elif item.activity_type == "followed_user" and item.related_user:
+            text = f"Followed {item.related_user.display_name}"
         else:
             text = item.activity_type
 
@@ -872,6 +876,48 @@ def unsave_recipe(recipe_id):
     db.session.commit()
 
     return redirect(url_for("saved_recipes"))
+
+## -------- Public User Profile Page ---------------------------------------------
+@app.route("/user/<int:user_id>", methods=["GET"])
+def user_profile(user_id):
+    redirect_response = login_required_redirect()
+    if redirect_response:
+        return redirect_response
+
+    current_user = get_current_user()
+    profile_user = User.query.get_or_404(user_id)
+
+    # Redirect to own profile page if viewing yourself
+    if profile_user.id == current_user.id:
+        return redirect(url_for("profile"))
+
+    recipes = (
+        Recipe.query
+        .filter_by(author_id=profile_user.id)
+        .order_by(Recipe.created_at.desc())
+        .all()
+    )
+
+    recipe_count = len(recipes)
+    follower_count = Follow.query.filter_by(following_id=profile_user.id).count()
+    following_count = Follow.query.filter_by(follower_id=profile_user.id).count()
+
+    is_following = Follow.query.filter_by(
+        follower_id=current_user.id,
+        following_id=profile_user.id
+    ).first() is not None
+
+    return render_template(
+        "user_profile.html",
+        **user_context(current_user),
+        profile_user=profile_user,
+        recipes=recipes,
+        recipe_count=recipe_count,
+        follower_count=follower_count,
+        following_count=following_count,
+        is_following=is_following,
+    )
+
 
 ## -------- Forgot Password Page ---------------------------------------------
 @app.route("/forgot-password", methods=["GET", "POST"])

--- a/main/routes.py
+++ b/main/routes.py
@@ -321,14 +321,10 @@ def following():
     following_ids = {row.following_id for row in following_rows}
 
     # Suggested: all users except yourself and those you already follow
-    suggested_users = (
-        User.query
-        .filter(User.id != user.id)
-        .filter(~User.id.in_(following_ids))
-        .order_by(func.random())
-        .limit(6)
-        .all()
-    )
+    base_query = User.query.filter(User.id != user.id)
+    if following_ids:
+        base_query = base_query.filter(~User.id.in_(following_ids))
+    suggested_users = base_query.order_by(func.random()).limit(6).all()
 
     return render_template(
         "following.html",

--- a/main/routes.py
+++ b/main/routes.py
@@ -347,6 +347,11 @@ def follow_user(user_id):
         already = Follow.query.filter_by(follower_id=user.id, following_id=user_id).first()
         if not already:
             db.session.add(Follow(follower_id=user.id, following_id=user_id))
+            db.session.add(Activity(
+                user_id=user.id,
+                activity_type="followed_user",
+                related_user_id=user_id,
+            ))
             db.session.commit()
 
     return redirect(request.referrer or url_for("following"))

--- a/main/routes.py
+++ b/main/routes.py
@@ -316,11 +316,23 @@ def following():
 
     following_rows = Follow.query.filter_by(follower_id=user.id).all()
     following_users = [row.following for row in following_rows]
+    following_ids = {row.following_id for row in following_rows}
+
+    # Suggested: all users except yourself and those you already follow
+    suggested_users = (
+        User.query
+        .filter(User.id != user.id)
+        .filter(~User.id.in_(following_ids))
+        .order_by(func.random())
+        .limit(6)
+        .all()
+    )
 
     return render_template(
         "following.html",
         **user_context(user),
         following=following_users,
+        suggested_users=suggested_users,
     )
 
 ## -------- Follow / Unfollow ---------------------------------------------

--- a/main/templates/explore.html
+++ b/main/templates/explore.html
@@ -54,11 +54,11 @@
         </div>
         <div class="recipe-body">
           <p class="recipe-name">{{ recipe.title }}</p>
-          <p class="recipe-by">by {{ recipe.author.display_name }}</p>
+          <p class="recipe-by">by <a href="{{ url_for('user_profile', user_id=recipe.author.id) }}" style="color:inherit; text-decoration:underline;">{{ recipe.author.display_name }}</a></p>
           <div class="recipe-meta">
             <span class="tag">{{ recipe.cuisine or '' }}</span>
             <span>{{ recipe.difficulty or '' }}</span>
-            <span>{{ recipe.prep_time or '?' }} min min</span>
+            <span>{{ recipe.prep_time or '?' }} min</span>
           </div>
           <a href="{{ url_for('recipe_details', recipe_id=recipe.id) }}" class="btn">View</a>
         </div>

--- a/main/templates/following.html
+++ b/main/templates/following.html
@@ -31,11 +31,13 @@
         {% if following %}
           {% for user in following %}
           <li class="follow-item">
-            <div class="avatar">{{ user.display_name[:2].upper() }}</div>
-            <div class="info">
-              <p class="uname">{{ user.display_name }}</p>
-              <p class="sub">{{ user.username }}</p>
-            </div>
+            <a href="{{ url_for('user_profile', user_id=user.id) }}" style="text-decoration:none; color:inherit; display:flex; align-items:center; gap:0.75rem; flex:1;">
+              <div class="avatar">{{ user.display_name[:2].upper() }}</div>
+              <div class="info">
+                <p class="uname">{{ user.display_name }}</p>
+                <p class="sub">@{{ user.username }}</p>
+              </div>
+            </a>
             <form method="POST" action="{{ url_for('unfollow_user', user_id=user.id) }}">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
               <button type="submit" class="btn-sm-follow">Following</button>
@@ -55,7 +57,25 @@
         <h3>Suggested accounts</h3>
       </div>
       <ul class="follow-list">
-        <p class="empty-state">No suggestions yet.</p>
+        {% if suggested_users %}
+          {% for u in suggested_users %}
+          <li class="follow-item">
+            <a href="{{ url_for('user_profile', user_id=u.id) }}" style="text-decoration:none; color:inherit; display:flex; align-items:center; gap:0.75rem; flex:1;">
+              <div class="avatar">{{ u.display_name[:2].upper() }}</div>
+              <div class="info">
+                <p class="uname">{{ u.display_name }}</p>
+                <p class="sub">@{{ u.username }}</p>
+              </div>
+            </a>
+            <form method="POST" action="{{ url_for('follow_user', user_id=u.id) }}">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+              <button type="submit" class="btn-sm-follow">Follow</button>
+            </form>
+          </li>
+          {% endfor %}
+        {% else %}
+        <p class="empty-state">You're following everyone already!</p>
+        {% endif %}
       </ul>
     </section>
   </div>

--- a/main/templates/profile.html
+++ b/main/templates/profile.html
@@ -90,7 +90,7 @@
         <p class="recipe-name">{{ recipe.title }}</p>
         <div class="recipe-meta">
           <span class="tag">{{ recipe.cuisine or '' }}</span>
-          <span>{{ recipe.prep_time or '?' }} min min</span>
+          <span>{{ recipe.prep_time or '?' }} min</span>
         </div>
         <a href="{{ url_for('recipe_details', recipe_id=recipe.id) }}" class="btn">View</a>
       </div>
@@ -118,7 +118,7 @@
         <p class="recipe-by">by {{ recipe.author.display_name }}</p>
         <div class="recipe-meta">
           <span class="tag">{{ recipe.cuisine or '' }}</span>
-          <span>{{ recipe.prep_time or '?' }} min min</span>
+          <span>{{ recipe.prep_time or '?' }} min</span>
         </div>
         <a href="{{ url_for('recipe_details', recipe_id=recipe.id) }}" class="btn">View</a>
       </div>

--- a/main/templates/recipe_details.html
+++ b/main/templates/recipe_details.html
@@ -16,16 +16,27 @@
     <div class="recipe-header">
       <h1>{{ recipe.title|default('Recipe title') }}</h1>
       <div class="recipe-meta">
-        {{ recipe.cuisine|default('Cuisine') }} · {{ recipe.prep_time|default('Time') }} minutes · {{ recipe.difficulty|default('Difficulty') }} · by {{ recipe.author.display_name|default(username|default('@username')) }}
+        {{ recipe.cuisine or 'Cuisine' }} · {{ recipe.prep_time or '?' }} minutes · {{ recipe.difficulty or 'Difficulty' }} ·
+        by <a href="{{ url_for('user_profile', user_id=recipe.author.id) }}" style="color:inherit; text-decoration:underline;">{{ recipe.author.display_name }}</a>
       </div>
     </div>
 
     <div class="actions">
-      <form action="{{ url_for('save_recipe', recipe_id=recipe_id|default(0)) }}" method="post" style="display:inline;">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        <button type="submit" class="btn primary">Save</button>
-      </form>
-      <button type="button" class="btn">Share</button>
+      {% if not is_own_recipe %}
+        {% if is_saved %}
+        <form action="{{ url_for('unsave_recipe', recipe_id=recipe_id) }}" method="post" style="display:inline;">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button type="submit" class="btn">Saved ✓</button>
+        </form>
+        {% else %}
+        <form action="{{ url_for('save_recipe', recipe_id=recipe_id) }}" method="post" style="display:inline;">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button type="submit" class="btn primary">Save</button>
+        </form>
+        {% endif %}
+      {% else %}
+      <a href="{{ url_for('edit_recipe', recipe_id=recipe_id) }}" class="btn">Edit</a>
+      {% endif %}
     </div>
 
     <div class="recipe-image">
@@ -76,14 +87,43 @@
   </div>
 
   <div>
+    <!-- Author card -->
     <div class="side-card">
-      <p class="empty-inline">Add supporting recipe details here.</p>
+      <div style="display:flex; align-items:center; gap:0.75rem; margin-bottom:0.75rem;">
+        <a href="{{ url_for('user_profile', user_id=recipe.author.id) }}" style="text-decoration:none; color:inherit; display:flex; align-items:center; gap:0.75rem;">
+          <div class="avatar">{{ recipe.author.display_name[:2].upper() }}</div>
+          <div>
+            <p style="font-weight:600; font-size:0.9rem;">{{ recipe.author.display_name }}</p>
+            <p style="font-size:0.78rem; color:var(--color-muted);">@{{ recipe.author.username }}</p>
+          </div>
+        </a>
+      </div>
+      {% if recipe.author.bio %}
+      <p style="font-size:0.82rem; color:var(--color-muted); margin-bottom:0.75rem;">{{ recipe.author.bio }}</p>
+      {% endif %}
+      {% if not is_own_recipe %}
+        {% if is_following_author %}
+        <form method="POST" action="{{ url_for('unfollow_user', user_id=recipe.author.id) }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          <button type="submit" class="btn" style="width:100%;">Following</button>
+        </form>
+        {% else %}
+        <form method="POST" action="{{ url_for('follow_user', user_id=recipe.author.id) }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          <button type="submit" class="btn primary" style="width:100%;">+ Follow</button>
+        </form>
+        {% endif %}
+      {% endif %}
     </div>
+
+    <!-- Recipe summary card -->
     <div class="side-card">
-      <p class="empty-inline">Add supporting recipe details here.</p>
-    </div>
-    <div class="side-card">
-      <p class="empty-inline">Add supporting recipe details here.</p>
+      <p style="font-weight:600; font-size:0.85rem; margin-bottom:0.5rem;">Recipe summary</p>
+      <p style="font-size:0.82rem; color:var(--color-muted);"> Serves {{ recipe.servings or '?' }}</p>
+      <p style="font-size:0.82rem; color:var(--color-muted);"> {{ recipe.prep_time or '?' }} min prep</p>
+      <p style="font-size:0.82rem; color:var(--color-muted);"> {{ recipe.difficulty or 'Unknown difficulty' }}</p>
+      <p style="font-size:0.82rem; color:var(--color-muted);"> {{ recipe.cuisine or 'Unknown cuisine' }}</p>
+      <p style="font-size:0.82rem; color:var(--color-muted);"> {{ recipe.meal_type or 'Any meal' }}</p>
     </div>
   </div>
 

--- a/main/templates/user_profile.html
+++ b/main/templates/user_profile.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ profile_user.display_name }} · Plateful{% endblock %}
+{% block body_class %}page-profile{% endblock %}
+
+{% block topbar %}
+<header class="topbar">
+  <div class="topbar-left">
+    <span class="hi">{{ profile_user.display_name }}</span>
+  </div>
+  <div class="topbar-right">
+    <a href="{{ url_for('upload_recipe') }}" class="btn-upload">+ New Recipe</a>
+  </div>
+</header>
+{% endblock %}

--- a/main/templates/user_profile.html
+++ b/main/templates/user_profile.html
@@ -13,3 +13,74 @@
   </div>
 </header>
 {% endblock %}
+
+{% block content %}
+<div class="profile-header">
+  <div class="profile-top">
+    <div class="avatar-lg">{{ profile_user.display_name[:2].upper() }}</div>
+
+    <div class="profile-identity">
+      <h2>{{ profile_user.display_name }}</h2>
+      <p class="handle">@{{ profile_user.username }} · joined {{ profile_user.joined_date.strftime('%Y') if profile_user.joined_date else '' }}</p>
+      <p class="bio">{{ profile_user.bio or '' }}</p>
+    </div>
+
+    <div class="profile-actions">
+      {% if is_following %}
+      <form method="POST" action="{{ url_for('unfollow_user', user_id=profile_user.id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <button type="submit" class="btn-edit">Following</button>
+      </form>
+      {% else %}
+      <form method="POST" action="{{ url_for('follow_user', user_id=profile_user.id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <button type="submit" class="btn-follow">+ Follow</button>
+      </form>
+      {% endif %}
+    </div>
+  </div>
+
+    <div class="profile-stats">
+    <div class="ps-item">
+      <p class="ps-value">{{ recipe_count }}</p>
+      <p class="ps-label">Recipes</p>
+    </div>
+    <div class="ps-item">
+      <p class="ps-value">{{ follower_count }}</p>
+      <p class="ps-label">Followers</p>
+    </div>
+    <div class="ps-item">
+      <p class="ps-value">{{ following_count }}</p>
+      <p class="ps-label">Following</p>
+    </div>
+  </div>
+</div>
+
+<div class="section-title" style="margin-top: 2rem;">
+  <h3>{{ profile_user.display_name }}'s recipes</h3>
+  <span style="font-size:0.78rem; color:var(--color-muted);">{{ recipe_count }} recipe{{ 's' if recipe_count != 1 else '' }}</span>
+</div>
+
+<div class="recipe-grid">
+  {% for recipe in recipes %}
+  <div class="recipe-card">
+    <div class="recipe-thumb">
+      {% if recipe.image_url %}
+      <img src="{{ url_for('static', filename=recipe.image_url) }}" alt="{{ recipe.title }}"/>
+      {% endif %}
+    </div>
+    <div class="recipe-body">
+      <p class="recipe-name">{{ recipe.title }}</p>
+      <div class="recipe-meta">
+        <span class="tag">{{ recipe.cuisine or '' }}</span>
+        <span>{{ recipe.difficulty or '' }}</span>
+        <span>{{ recipe.prep_time or '?' }} min</span>
+      </div>
+      <a href="{{ url_for('recipe_details', recipe_id=recipe.id) }}" class="btn">View</a>
+    </div>
+  </div>
+  {% else %}
+  <p class="empty-state">{{ profile_user.display_name }} hasn't posted any recipes yet.</p>
+  {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
- Add public user profile page at `/user/<user_id>` showing bio, stats, recipe grid, and follow/unfollow button
- Wire up suggested accounts on the following page which shows up to 6 random users(customisable) you don't follow yet
- Author names on explore page and recipe details are now clickable links to their public profile
- Recipe details side panel now has a real author card with follow/unfollow button and a recipe summary card
- Save button on recipe details toggles to "Saved ✓" (with unsave action) if already saved; own recipes show Edit instead
- Follow actions now log an Activity record, visible in dashboard and profile activity feeds
- Fix cascade delete on Recipe — ingredients, steps, and saved_by now correctly delete when a recipe is deleted
- Fix `min min` typo in prep time display on profile and explore pages

Tests to run(optional)
- Log in as demo user, go to Explore, click an author name — should land on their public profile
- From the public profile, click Follow — should update to Following
- Go to Following page — followed user should appear in the left list, remaining users in Suggested
- Open a recipe by another user — author card in sidebar should show Follow button
- Save a recipe, revisit recipe details — button should show "Saved ✓"
- View your own recipe — should show Edit button, no Follow button on author card
- Check dashboard activity feed — following someone should appear as "Followed [name]"
- Delete a recipe — should not leave orphaned ingredients or steps in the DB

closes #95 
closes #96 
closes #97